### PR TITLE
Update Python version matrix to include 3.14

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - extras=s3-cache
     strategy:
       matrix:
-        python_version: ['3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5


### PR DESCRIPTION
3.14 is out now, so I'm adding it to the test matrix