### PR TITLE
Update CODEOWNERS: @citizensadvice/devops → @citizensadvice/cloud-engineering

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @citizensadvice/devops
+* @citizensadvice/cloud-engineering


### PR DESCRIPTION
This PR updates CODEOWNERS to replace `@citizensadvice/devops` with `@citizensadvice/cloud-engineering` as part of the team permission migration.

This PR was generated automatically.