### PR TITLE
fix: resolve type errors caught by ty upgrade to 0.0.32

### DIFF
--- a/ca_cdk8s_constructs/blackbox_probe.py
+++ b/ca_cdk8s_constructs/blackbox_probe.py
@@ -49,12 +49,11 @@ def ca_blackbox_probe(
         being the generated name of the ingress. As the name is generated
         by cdk8s with a hashed suffix we can be sure that it is unique.
         """
-        target.metadata.add_label(LABEL_KEY, f"{target.name}")
+        label_value = target.name
+        target.metadata.add_label(LABEL_KEY, label_value)
         probe_target = Targets(
             ingress=IngressTarget(
-                selector=IngressSelector(
-                    match_labels={LABEL_KEY: target.metadata.get_label(LABEL_KEY)}
-                )
+                selector=IngressSelector(match_labels={LABEL_KEY: label_value})
             )
         )
     elif isinstance(target, str):

--- a/ca_cdk8s_constructs/helpers.py
+++ b/ca_cdk8s_constructs/helpers.py
@@ -1,10 +1,10 @@
 """A collection of helper functions for cdk8s applications."""
 
 import cdk8s
-from constructs import Construct
+from constructs import IConstruct
 
 
-def add_labels(construct: Construct, labels: dict[str, str]) -> None:
+def add_labels(construct: IConstruct, labels: dict[str, str]) -> None:
     """
     Recursively add the supplied labels to all resources in
     the construct and all its children that have a metadata
@@ -24,7 +24,7 @@ def add_labels(construct: Construct, labels: dict[str, str]) -> None:
         add_labels(resource, labels)
 
 
-def add_annotations(construct: Construct, annotations: dict[str, str]) -> None:
+def add_annotations(construct: IConstruct, annotations: dict[str, str]) -> None:
     """
     Recursively add the supplied labels to all resources in
     the construct and all its children that have a metadata


### PR DESCRIPTION
## Summary

- `blackbox_probe.py`: store label value in a local variable instead of re-fetching via `get_label()` (which returns `str | None`), avoiding a type mismatch with `match_labels: Mapping[str, str]`
- `helpers.py`: change `construct` parameter type from `Construct` to `IConstruct` in `add_labels` and `add_annotations`, since `node.children` yields `IConstruct`